### PR TITLE
Fix #43: Rescan any fields that have not been converted

### DIFF
--- a/graphene_mongo/converter.py
+++ b/graphene_mongo/converter.py
@@ -89,7 +89,6 @@ def convert_field_to_dynamic(field, registry=None):
         _type = registry.get_type_for_model(model)
         if not _type:
             return None
-
         return Field(_type)
 
     return Dynamic(dynamic_type)

--- a/graphene_mongo/registry.py
+++ b/graphene_mongo/registry.py
@@ -11,6 +11,10 @@ class Registry(object):
         assert cls._meta.registry == self, 'Registry for a Model have to match.'
         self._registry[cls._meta.model] = cls
 
+        # Rescan all fields
+        for model, cls in self._registry.items():
+            cls.rescan_fields()
+
     def get_type_for_model(self, model):
         return self._registry.get(model)
 

--- a/graphene_mongo/tests/models.py
+++ b/graphene_mongo/tests/models.py
@@ -98,3 +98,25 @@ class ProfessorVector(Document):
     meta = {'collection': 'test_professor_vector'}
     vec = ListField(FloatField())
     metadata = EmbeddedDocumentField(ProfessorMetadata)
+
+
+class ParentWithRelationship(Document):
+
+    meta = {'collection': 'test_parent_reference'}
+    before_child = ReferenceField("ChildRegisteredBefore")
+    after_child = ReferenceField("ChildRegisteredAfter")
+    name = StringField()
+
+
+class ChildRegisteredBefore(Document):
+
+    meta = {'collection': 'test_child_before_reference'}
+    parent = ReferenceField(ParentWithRelationship)
+    name = StringField()
+
+
+class ChildRegisteredAfter(Document):
+
+    meta = {'collection': 'test_child_after_reference'}
+    parent = ReferenceField(ParentWithRelationship)
+    name = StringField()

--- a/graphene_mongo/tests/models.py
+++ b/graphene_mongo/tests/models.py
@@ -103,8 +103,8 @@ class ProfessorVector(Document):
 class ParentWithRelationship(Document):
 
     meta = {'collection': 'test_parent_reference'}
-    before_child = ReferenceField("ChildRegisteredBefore")
-    after_child = ReferenceField("ChildRegisteredAfter")
+    before_child = ListField(ReferenceField("ChildRegisteredBefore"))
+    after_child = ListField(ReferenceField("ChildRegisteredAfter"))
     name = StringField()
 
 

--- a/graphene_mongo/tests/setup.py
+++ b/graphene_mongo/tests/setup.py
@@ -120,7 +120,12 @@ def fixtures():
     child3.save()
     child4.save()
 
-    parent = ParentWithRelationship(name="Yui", before_child=child3, after_child=child4)
+    parent = ParentWithRelationship(
+        name="Yui",
+        before_child=[child3],
+        after_child=[child4]
+    )
+
     parent.save()
 
     child3.parent = child4.parent = parent

--- a/graphene_mongo/tests/setup.py
+++ b/graphene_mongo/tests/setup.py
@@ -2,6 +2,8 @@ import pytest
 from .models import (
     Article, Editor, EmbeddedArticle, Player,
     Reporter, Child, ProfessorMetadata, ProfessorVector,
+    ChildRegisteredBefore, ChildRegisteredAfter,
+    ParentWithRelationship
 )
 
 
@@ -105,3 +107,22 @@ def fixtures():
         metadata=professor_metadata
     )
     professor_vector.save()
+
+    ParentWithRelationship.drop_collection()
+    ChildRegisteredAfter.drop_collection()
+    ChildRegisteredBefore.drop_collection()
+
+    # This is one messed up family
+
+    # She'd better have presence this time
+    child3 = ChildRegisteredBefore(name="Akari")
+    child4 = ChildRegisteredAfter(name="Kyouko")
+    child3.save()
+    child4.save()
+
+    parent = ParentWithRelationship(name="Yui", before_child=child3, after_child=child4)
+    parent.save()
+
+    child3.parent = child4.parent = parent
+    child3.save()
+    child4.save()

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -10,7 +10,8 @@ from .types import (ArticleNode,
                     EditorNode,
                     PlayerNode,
                     ReporterNode,
-                    ChildNode,)
+                    ChildNode,
+                    ParentWithRelationshipNode)
 from ..fields import MongoengineConnectionField
 
 
@@ -644,6 +645,56 @@ def test_should_self_reference(fixtures):
         }
     }
     schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+    assert not result.errors
+    assert json.dumps(result.data, sort_keys=True) == json.dumps(
+        expected, sort_keys=True)
+
+
+def test_should_lazy_reference(fixtures):
+
+    class Query(graphene.ObjectType):
+        node = Node.Field()
+        parents = MongoengineConnectionField(ParentWithRelationshipNode)
+
+    schema = graphene.Schema(query=Query)
+
+    query = """
+    query {
+        parents {
+            edges {
+                node {
+                    beforeChild {
+                        name,
+                        parent { name }
+                    },
+                    afterChild {
+                        name,
+                        parent { name }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    expected = {
+        "parents": {
+            "edges": [
+                {"node": {
+                    "beforeChild": {
+                        "name": "Akari",
+                        "parent": {"name": "Yui"}
+                    },
+                    "afterChild": {
+                        "name": "Kyouko",
+                        "parent": {"name": "Yui"}
+                    }
+                }}
+            ]
+        }
+    }
+
     result = schema.execute(query)
     assert not result.errors
     assert json.dumps(result.data, sort_keys=True) == json.dumps(

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -665,12 +665,20 @@ def test_should_lazy_reference(fixtures):
             edges {
                 node {
                     beforeChild {
-                        name,
-                        parent { name }
+                        edges {
+                            node {
+                                name,
+                                parent { name }
+                            }
+                        }
                     },
                     afterChild {
-                        name,
-                        parent { name }
+                        edges {
+                            node {
+                                name,
+                                parent { name }
+                            }
+                        }
                     }
                 }
             }
@@ -683,12 +691,20 @@ def test_should_lazy_reference(fixtures):
             "edges": [
                 {"node": {
                     "beforeChild": {
-                        "name": "Akari",
-                        "parent": {"name": "Yui"}
+                        "edges": [
+                            {"node": {
+                                "name": "Akari",
+                                "parent": {"name": "Yui"}
+                            }}
+                        ]
                     },
                     "afterChild": {
-                        "name": "Kyouko",
-                        "parent": {"name": "Yui"}
+                        "edges": [
+                            {"node": {
+                                "name": "Kyouko",
+                                "parent": {"name": "Yui"}
+                            }}
+                        ]
                     }
                 }}
             ]

--- a/graphene_mongo/tests/types.py
+++ b/graphene_mongo/tests/types.py
@@ -4,6 +4,8 @@ from ..types import MongoengineObjectType
 from .models import (
     Article, Editor, EmbeddedArticle, Player, Reporter,
     Parent, Child, ProfessorMetadata, ProfessorVector,
+    ParentWithRelationship, ChildRegisteredBefore,
+    ChildRegisteredAfter
 )
 
 
@@ -107,3 +109,21 @@ class ChildNode(MongoengineObjectType):
     class Meta:
         model = Child
         interfaces = (Node,)
+
+
+class ChildRegisteredBeforeNode(MongoengineObjectType):
+    class Meta:
+        model = ChildRegisteredBefore
+        interfaces = (Node, )
+
+
+class ParentWithRelationshipNode(MongoengineObjectType):
+    class Meta:
+        model = ParentWithRelationship
+        interfaces = (Node, )
+
+
+class ChildRegisteredAfterNode(MongoengineObjectType):
+    class Meta:
+        model = ChildRegisteredAfter
+        interfaces = (Node, )

--- a/graphene_mongo/types.py
+++ b/graphene_mongo/types.py
@@ -80,7 +80,6 @@ class MongoengineObjectType(ObjectType):
             model, registry, only_fields, exclude_fields
         )
         mongoengine_fields = yank_fields_from_attrs(converted_fields, _as=Field)
-
         if use_connection is None and interfaces:
             use_connection = any((issubclass(interface, Node) for interface in interfaces))
 
@@ -103,6 +102,9 @@ class MongoengineObjectType(ObjectType):
         _meta.fields = mongoengine_fields
         _meta.filter_fields = filter_fields
         _meta.connection = connection
+        # Save them for later
+        _meta.only_fields = only_fields
+        _meta.exclude_fields = exclude_fields
 
         super(MongoengineObjectType, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options
@@ -116,6 +118,16 @@ class MongoengineObjectType(ObjectType):
                 mongoengine_fields = yank_fields_from_attrs(converted_fields, _as=Field)
                 cls._meta.fields.update(mongoengine_fields)
                 registry.register(cls)
+
+    @classmethod
+    def rescan_fields(cls):
+        converted_fields, self_referenced = construct_fields(
+            cls._meta.model, cls._meta.registry, cls._meta.only_fields,
+            cls._meta.exclude_fields
+        )
+        mongoengine_fields = yank_fields_from_attrs(converted_fields, _as=Field)
+        cls._meta.fields.update(mongoengine_fields)
+
 
     # noqa
     @classmethod


### PR DESCRIPTION
Directly from #43, if a field has not been converted when it was registered, another conversion attempt will take place on every subsequent register

doesn't break any tests and seems to fix my use case :^)