### PR TITLE
Fix type obtaining by string

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -93,7 +93,7 @@ class MongoengineConnectionField(ConnectionField):
 
     @property
     def fields(self):
-        return self._type._meta.fields
+        return self.type._meta.fields
 
     @classmethod
     def get_query(cls, model, info, **args):


### PR DESCRIPTION
Example:

class Post(MongoengineObjectType):
    comments = MongoengineConnectionField('post.types.Post')

AttributeError: 'str' object has no attribute '_meta'