### PR TITLE
Feat refine reference args on embedded document

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -64,11 +64,10 @@ class MongoengineConnectionField(ConnectionField):
 
     @property
     def args(self):
-        args = to_arguments(
+        return to_arguments(
             self._base_args or OrderedDict(),
             dict(self.field_args, **self.reference_args)
         )
-        return args
 
     @args.setter
     def args(self, args):

--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import mongoengine
 from collections import OrderedDict
 from functools import partial, reduce
 
@@ -69,7 +70,6 @@ class MongoengineConnectionField(ConnectionField):
         )
         return args
 
-
     @args.setter
     def args(self, args):
         self._base_args = args
@@ -94,7 +94,7 @@ class MongoengineConnectionField(ConnectionField):
         def get_reference_field(r, kv):
             if callable(getattr(kv[1], 'get_type', None)):
                 node = kv[1].get_type()._type._meta
-                if not isinstance(kv[1], Dynamic):
+                if not issubclass(node.model, mongoengine.EmbeddedDocument):
                     r.update({kv[0]: node.fields['id']._type.of_type()})
             return r
         return reduce(get_reference_field, self.fields.items(), {})

--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -67,7 +67,6 @@ class MongoengineConnectionField(ConnectionField):
             self._base_args or OrderedDict(),
             dict(self.field_args, **self.reference_args)
         )
-        print('args', args)
         return args
 
 
@@ -95,9 +94,7 @@ class MongoengineConnectionField(ConnectionField):
         def get_reference_field(r, kv):
             if callable(getattr(kv[1], 'get_type', None)):
                 node = kv[1].get_type()._type._meta
-                if isinstance(kv[1], Dynamic):
-                    r.update({kv[0]: self._field_args(node.fields.items())})
-                else:
+                if not isinstance(kv[1], Dynamic):
                     r.update({kv[0]: node.fields['id']._type.of_type()})
             return r
         return reduce(get_reference_field, self.fields.items(), {})
@@ -113,7 +110,6 @@ class MongoengineConnectionField(ConnectionField):
             return [], 0
 
         objs = model.objects()
-        print('hahaha', args)
         if args:
             reference_fields = get_model_reference_fields(model)
             reference_args = {}

--- a/graphene_mongo/tests/models.py
+++ b/graphene_mongo/tests/models.py
@@ -91,6 +91,7 @@ class ProfessorVector(Document):
 
     meta = {'collection': 'test_professor_vector'}
     vec = ListField(FloatField())
+    last_name = StringField()
     metadata = EmbeddedDocumentField(ProfessorMetadata)
 
 

--- a/graphene_mongo/tests/models.py
+++ b/graphene_mongo/tests/models.py
@@ -91,7 +91,6 @@ class ProfessorVector(Document):
 
     meta = {'collection': 'test_professor_vector'}
     vec = ListField(FloatField())
-    last_name = StringField()
     metadata = EmbeddedDocumentField(ProfessorMetadata)
 
 

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 import graphene
 
@@ -11,7 +12,8 @@ from .types import (ArticleNode,
                     PlayerNode,
                     ReporterNode,
                     ChildNode,
-                    ParentWithRelationshipNode)
+                    ParentWithRelationshipNode,
+                    ProfessorVectorNode,)
 from ..fields import MongoengineConnectionField
 
 
@@ -726,3 +728,39 @@ def test_should_lazy_reference(fixtures):
     assert not result.errors
     assert json.dumps(result.data, sort_keys=True) == json.dumps(
         expected, sort_keys=True)
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_should_query_with_embedded_document(fixtures):
+
+    class Query(graphene.ObjectType):
+
+        all_professors = MongoengineConnectionField(ProfessorVectorNode)
+
+    query = '''
+        query EditorQuery {
+          allProfessors() {
+            edges {
+                node {
+                    vec
+                }
+            }
+          }
+        }
+    '''
+    expected = {
+        'allProfessors': {
+            'edges': [
+                {
+                    'node': {
+                        # 'id': 'abc',
+                        'vec': [1.0, 2.3]
+                    }
+
+                }
+            ]
+        }
+    }
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+    # assert not result.errors
+    # assert dict(result.data['allProfessors']) == expected['allProfessors']

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -738,7 +738,7 @@ def test_should_query_with_embedded_document(fixtures):
 
     query = '''
     query {
-      allProfessors(lastName: "5e06aa20-6805-4eef-a144-5615dedbe32b") {
+      allProfessors {
         edges {
             node {
                 vec

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -729,7 +729,7 @@ def test_should_lazy_reference(fixtures):
     assert json.dumps(result.data, sort_keys=True) == json.dumps(
         expected, sort_keys=True)
 
-# @pytest.mark.skip(reason="no way of currently testing this")
+
 def test_should_query_with_embedded_document(fixtures):
 
     class Query(graphene.ObjectType):
@@ -741,7 +741,10 @@ def test_should_query_with_embedded_document(fixtures):
       allProfessors {
         edges {
             node {
-                vec
+                vec,
+                metadata {
+                     firstName
+                }
             }
         }
       }
@@ -752,7 +755,10 @@ def test_should_query_with_embedded_document(fixtures):
             'edges': [
                 {
                     'node': {
-                        'vec': [1.0, 2.3]
+                        'vec': [1.0, 2.3],
+                        'metadata': {
+                             'firstName': 'Steven'
+                        }
                     }
 
                 }
@@ -761,6 +767,5 @@ def test_should_query_with_embedded_document(fixtures):
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(query)
-    print(result.data)
-    # assert not result.errors
-    # assert dict(result.data['allProfessors']) == expected['allProfessors']
+    assert not result.errors
+    assert dict(result.data['allProfessors']) == expected['allProfessors']

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -729,7 +729,7 @@ def test_should_lazy_reference(fixtures):
     assert json.dumps(result.data, sort_keys=True) == json.dumps(
         expected, sort_keys=True)
 
-@pytest.mark.skip(reason="no way of currently testing this")
+# @pytest.mark.skip(reason="no way of currently testing this")
 def test_should_query_with_embedded_document(fixtures):
 
     class Query(graphene.ObjectType):
@@ -737,22 +737,21 @@ def test_should_query_with_embedded_document(fixtures):
         all_professors = MongoengineConnectionField(ProfessorVectorNode)
 
     query = '''
-        query EditorQuery {
-          allProfessors() {
-            edges {
-                node {
-                    vec
-                }
+    query {
+      allProfessors(lastName: "5e06aa20-6805-4eef-a144-5615dedbe32b") {
+        edges {
+            node {
+                vec
             }
-          }
         }
+      }
+    }
     '''
     expected = {
         'allProfessors': {
             'edges': [
                 {
                     'node': {
-                        # 'id': 'abc',
                         'vec': [1.0, 2.3]
                     }
 
@@ -762,5 +761,6 @@ def test_should_query_with_embedded_document(fixtures):
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(query)
+    print(result.data)
     # assert not result.errors
     # assert dict(result.data['allProfessors']) == expected['allProfessors']

--- a/graphene_mongo/tests/types.py
+++ b/graphene_mongo/tests/types.py
@@ -106,24 +106,35 @@ class ParentNode(MongoengineObjectType):
 
 
 class ChildNode(MongoengineObjectType):
+
     class Meta:
         model = Child
         interfaces = (Node,)
 
 
 class ChildRegisteredBeforeNode(MongoengineObjectType):
+
     class Meta:
         model = ChildRegisteredBefore
         interfaces = (Node, )
 
 
 class ParentWithRelationshipNode(MongoengineObjectType):
+
     class Meta:
         model = ParentWithRelationship
         interfaces = (Node, )
 
 
 class ChildRegisteredAfterNode(MongoengineObjectType):
+
     class Meta:
         model = ChildRegisteredAfter
+        interfaces = (Node, )
+
+
+class ProfessorVectorNode(MongoengineObjectType):
+
+    class Meta:
+        model = ProfessorVector
         interfaces = (Node, )


### PR DESCRIPTION
- Remove `EmbeddedDocument` type from `fields.reference_args` at this moment.