### PR TITLE
Feat: Take point type more properly

### DIFF
--- a/graphene_mongo/advanced_types.py
+++ b/graphene_mongo/advanced_types.py
@@ -1,0 +1,15 @@
+import graphene
+
+
+def _resolve_point_type_coordinates(self, info):
+    return self['coordinates']
+
+
+class PointType(graphene.ObjectType):
+
+    type = graphene.String()
+    coordinates = graphene.List(
+        graphene.Float, resolver=_resolve_point_type_coordinates)
+
+    def resolve_type(self, info):
+        return self['type']

--- a/graphene_mongo/advanced_types.py
+++ b/graphene_mongo/advanced_types.py
@@ -1,11 +1,16 @@
 import graphene
 
 
+__all__ = [
+    'PointFieldType'
+]
+
+
 def _resolve_point_type_coordinates(self, info):
     return self['coordinates']
 
 
-class PointType(graphene.ObjectType):
+class PointFieldType(graphene.ObjectType):
 
     type = graphene.String()
     coordinates = graphene.List(

--- a/graphene_mongo/converter.py
+++ b/graphene_mongo/converter.py
@@ -12,11 +12,11 @@ from graphene import (
     String,
     is_node
 )
-from graphene.types.resolver import dict_resolver
 from graphene.types.json import JSONString
 
 import mongoengine
 
+from .advanced_types import PointType
 from .fields import MongoengineConnectionField
 from .utils import import_single_dispatch
 
@@ -66,25 +66,9 @@ def convert_dict_to_jsonstring(field, registry=None):
     return JSONString(description=field.db_field, required=field.required)
 
 
-def resolve_type(self, info):
-    return self['type']
-
-def resolve_cooridinates(self, info):
-    return self['coordinates']
-
-
 @convert_mongoengine_field.register(mongoengine.PointField)
 def convert_point_to_field(field, register=None):
-    class Point(ObjectType):
-        type = String(resolver=resolve_type)
-        coordinates = List(Float,resolver=resolve_cooridinates)
-        def resolve_type(self, info):
-            return self['type']
-
-        def resolve_cooridinates(self, info):
-            return self['coordinates']
-
-    return Field(Point)
+    return Field(PointType)
 
 
 @convert_mongoengine_field.register(mongoengine.DateTimeField)

--- a/graphene_mongo/converter.py
+++ b/graphene_mongo/converter.py
@@ -8,7 +8,6 @@ from graphene import (
     Int,
     List,
     NonNull,
-    ObjectType,
     String,
     is_node
 )
@@ -16,7 +15,7 @@ from graphene.types.json import JSONString
 
 import mongoengine
 
-from .advanced_types import PointType
+from .advanced_types import PointFieldType
 from .fields import MongoengineConnectionField
 from .utils import import_single_dispatch
 
@@ -68,7 +67,7 @@ def convert_dict_to_jsonstring(field, registry=None):
 
 @convert_mongoengine_field.register(mongoengine.PointField)
 def convert_point_to_field(field, register=None):
-    return Field(PointType)
+    return Field(PointFieldType)
 
 
 @convert_mongoengine_field.register(mongoengine.DateTimeField)

--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -4,7 +4,6 @@ import mongoengine
 from collections import OrderedDict
 from functools import partial, reduce
 
-from graphene import Field, List
 from graphene.relay import ConnectionField
 from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
@@ -14,25 +13,6 @@ from graphene.types.dynamic import Dynamic
 from graphene.types.structures import Structure
 
 from .utils import get_model_reference_fields
-
-
-# noqa
-class MongoengineListField(Field):
-
-    def __init__(self, _type, *args, **kwargs):
-        super(MongoengineListField, self).__init__(
-            List(_type), *args, **kwargs)
-
-    @property
-    def model(self):
-        return self.type.of_type._meta.node._meta.model
-
-    # @staticmethod
-    # def list_resolver(resolver, root, info, **args):
-    #    return maybe_queryset(resolver(root, info, **args))
-
-    def get_resolver(self, parent_resolver):
-        return partial(self.list_resolver, parent_resolver)
 
 
 class MongoengineConnectionField(ConnectionField):

--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -12,6 +12,7 @@ from graphene.types.argument import to_arguments
 from graphene.types.dynamic import Dynamic
 from graphene.types.structures import Structure
 
+from .advanced_types import PointFieldType
 from .utils import get_model_reference_fields
 
 
@@ -55,7 +56,13 @@ class MongoengineConnectionField(ConnectionField):
 
     def _field_args(self, items):
         def is_filterable(v):
-            return not isinstance(v, (ConnectionField, Dynamic))
+            if isinstance(v, (ConnectionField, Dynamic)):
+                return False
+            # FIXME: Skip PointTypeField at this moment.
+            if not isinstance(v.type, Structure) \
+                    and isinstance(v.type(), PointFieldType):
+                return False
+            return True
 
         def get_type(v):
             if isinstance(v.type, Structure):

--- a/graphene_mongo/tests/test_converter.py
+++ b/graphene_mongo/tests/test_converter.py
@@ -78,7 +78,7 @@ def test_should_dict_convert_json():
     assert_conversion(mongoengine.DictField, graphene.JSONString)
 
 
-def test_should_map_convertjson():
+def test_should_map_convert_json():
     assert_conversion(mongoengine.MapField, graphene.JSONString, field=mongoengine.StringField())
 
 

--- a/graphene_mongo/tests/test_converter.py
+++ b/graphene_mongo/tests/test_converter.py
@@ -1,8 +1,9 @@
 import graphene
 import mongoengine
 
-from graphene import Dynamic
-from graphene import Node
+from graphene import (
+    Dynamic, Node
+)
 
 from py.test import raises
 
@@ -82,23 +83,11 @@ def test_should_map_convert_json():
     assert_conversion(mongoengine.MapField, graphene.JSONString, field=mongoengine.StringField())
 
 
-# def test_should_point_convert_json():
-#     assert_conversion(mongoengine.PointField, graphene.JSONString)
-
 def test_should_point_convert_field():
-    # def assert_conversion(mongoengine_field, graphene_field, *args, **kwargs):
-    # field = mongoengine_field(*args, **kwargs)
-    # graphene_type = convert_mongoengine_field(field)
-    # assert isinstance(graphene_type, graphene_field)
-    # field = graphene_type.Field()
-    # return field
-    # assert_conversion(mongoengine.PointField, graphene.ObjectType)
-
     graphene_type = convert_mongoengine_field(mongoengine.PointField())
-    assert isinstance(graphene_type, graphene.ObjectType)
-    # print(graphene_type)
-    # assert isinstance(graphene_type, graphene_field)
-    # field = graphene_type.Field()
+    assert isinstance(graphene_type, graphene.Field)
+    assert isinstance(graphene_type.type.type, graphene.String)
+    assert isinstance(graphene_type.type.coordinates, graphene.List)
 
 
 def test_should_field_convert_list():

--- a/graphene_mongo/tests/test_converter.py
+++ b/graphene_mongo/tests/test_converter.py
@@ -82,8 +82,23 @@ def test_should_map_convert_json():
     assert_conversion(mongoengine.MapField, graphene.JSONString, field=mongoengine.StringField())
 
 
-def test_should_point_convert_json():
-    assert_conversion(mongoengine.PointField, graphene.JSONString)
+# def test_should_point_convert_json():
+#     assert_conversion(mongoengine.PointField, graphene.JSONString)
+
+def test_should_point_convert_field():
+    # def assert_conversion(mongoengine_field, graphene_field, *args, **kwargs):
+    # field = mongoengine_field(*args, **kwargs)
+    # graphene_type = convert_mongoengine_field(field)
+    # assert isinstance(graphene_type, graphene_field)
+    # field = graphene_type.Field()
+    # return field
+    # assert_conversion(mongoengine.PointField, graphene.ObjectType)
+
+    graphene_type = convert_mongoengine_field(mongoengine.PointField())
+    assert isinstance(graphene_type, graphene.ObjectType)
+    # print(graphene_type)
+    # assert isinstance(graphene_type, graphene_field)
+    # field = graphene_type.Field()
 
 
 def test_should_field_convert_list():

--- a/graphene_mongo/tests/test_query.py
+++ b/graphene_mongo/tests/test_query.py
@@ -4,10 +4,10 @@ import graphene
 
 from .setup import fixtures
 from .models import (
-    Editor, Player, Reporter, ProfessorVector
+    Child, Editor, Player, Reporter, ProfessorVector
 )
 from .types import (
-    EditorType, PlayerType, ReporterType, ProfessorVectorType
+    ChildType, EditorType, PlayerType, ReporterType, ProfessorVectorType
 )
 
 
@@ -265,3 +265,43 @@ def test_should_query_with_embedded_document(fixtures):
     assert not result.errors
     assert json.dumps(result.data, sort_keys=True) == \
         json.dumps(expected, sort_keys=True)
+
+
+def test_should_query_child(fixtures):
+
+    class Query(graphene.ObjectType):
+
+        children = graphene.List(ChildType)
+
+        def resolve_children(self, *args, **kwargs):
+            return list(Child.objects.all())
+
+    query = '''
+        query Query {
+            children {
+                bar,
+                baz,
+                loc {
+                     type,
+                     coordinates
+                }
+            }
+        }
+    '''
+    expected = {
+        'editors': [{
+        }]
+    }
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+    # assert not result.errors
+    print('result.data', result.data)
+    # print('abaw')
+    print(ChildType._meta.fields)
+    # metadata = result.data['editor'].pop('metadata')
+    # expected_metadata = expected['editor'].pop('metadata')
+    # assert(json.loads(metadata)) == dict(json.loads(expected_metadata))
+    # assert dict(result.data['editor']) == expected['editor']
+    # assert all(item in result.data['editors'] for item in expected['editors'])
+

--- a/graphene_mongo/tests/test_query.py
+++ b/graphene_mongo/tests/test_query.py
@@ -289,19 +289,24 @@ def test_should_query_child(fixtures):
         }
     '''
     expected = {
-        'editors': [{
-        }]
+        'children': [
+            {
+                'bar': 'BAR',
+                'baz': 'BAZ',
+                'loc': None
+            }, {
+                'bar': 'bar',
+                'baz': 'baz',
+                'loc': {
+                    'type': 'Point',
+                    'coordinates': [10.0, 20.0]
+                }
+            }
+        ]
     }
 
     schema = graphene.Schema(query=Query)
     result = schema.execute(query)
-    # assert not result.errors
-    print('result.data', result.data)
-    # print('abaw')
-    print(ChildType._meta.fields)
-    # metadata = result.data['editor'].pop('metadata')
-    # expected_metadata = expected['editor'].pop('metadata')
-    # assert(json.loads(metadata)) == dict(json.loads(expected_metadata))
-    # assert dict(result.data['editor']) == expected['editor']
-    # assert all(item in result.data['editors'] for item in expected['editors'])
-
+    assert not result.errors
+    assert json.dumps(result.data, sort_keys=True) == \
+        json.dumps(expected, sort_keys=True)

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -303,7 +303,9 @@ def test_should_filter_through_inheritance(fixtures):
                     node {
                         bar,
                         baz,
-                        loc
+                        loc {
+                             type
+                        }
                     }
                 }
             }
@@ -329,11 +331,13 @@ def test_should_filter_through_inheritance(fixtures):
     schema = graphene.Schema(query=Query)
 
     result = schema.execute(query)
-    result_loc = json.loads(result.data['children']['edges'][0]['node'].pop('loc'))
-    assert not result.errors
-    assert json.dumps(result.data, sort_keys=True) == json.dumps(
-        expected, sort_keys=True)
-    assert json.dumps(result_loc, sort_keys=True) == loc_json_string
+    print(result.data)
+    print(result.errors)
+    # result_loc = json.loads(result.data['children']['edges'][0]['node'].pop('loc'))
+    # assert not result.errors
+    # assert json.dumps(result.data, sort_keys=True) == json.dumps(
+    #     expected, sort_keys=True)
+    # assert json.dumps(result_loc, sort_keys=True) == loc_json_string
 
 
 def test_should_get_node_by_id(fixtures):

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -304,7 +304,8 @@ def test_should_filter_through_inheritance(fixtures):
                         bar,
                         baz,
                         loc {
-                             type
+                             type,
+                             coordinates
                         }
                     }
                 }
@@ -318,26 +319,20 @@ def test_should_filter_through_inheritance(fixtures):
                     'node': {
                         'bar': 'bar',
                         'baz': 'baz',
+                        'loc': {
+                             'type': 'Point',
+                             'coordinates': [10.0, 20.0]
+                        }
                     }
                 }
             ]
         }
     }
-    loc = {
-         'type': 'Point',
-         'coordinates': [10, 20]
-    }
-    loc_json_string = json.dumps(loc, sort_keys=True)
     schema = graphene.Schema(query=Query)
-
     result = schema.execute(query)
-    print(result.data)
-    print(result.errors)
-    # result_loc = json.loads(result.data['children']['edges'][0]['node'].pop('loc'))
-    # assert not result.errors
-    # assert json.dumps(result.data, sort_keys=True) == json.dumps(
-    #     expected, sort_keys=True)
-    # assert json.dumps(result_loc, sort_keys=True) == loc_json_string
+    assert not result.errors
+    assert json.dumps(result.data, sort_keys=True) == json.dumps(
+        expected, sort_keys=True)
 
 
 def test_should_get_node_by_id(fixtures):

--- a/graphene_mongo/types.py
+++ b/graphene_mongo/types.py
@@ -9,7 +9,7 @@ from mongoengine import ListField
 from .converter import convert_mongoengine_field
 from .registry import Registry, get_global_registry
 from .utils import (get_model_fields, is_valid_mongoengine_model)
-
+from .tests.models import Child
 
 def construct_fields(model, registry, only_fields, exclude_fields):
     _model_fields = get_model_fields(model)
@@ -35,6 +35,9 @@ def construct_fields(model, registry, only_fields, exclude_fields):
             continue
         fields[name] = converted
 
+    # print(model, model == Child)
+    # if model == Child:
+    #     print(fields)
     return fields, self_referenced
 
 

--- a/graphene_mongo/types.py
+++ b/graphene_mongo/types.py
@@ -9,7 +9,7 @@ from mongoengine import ListField
 from .converter import convert_mongoengine_field
 from .registry import Registry, get_global_registry
 from .utils import (get_model_fields, is_valid_mongoengine_model)
-from .tests.models import Child
+
 
 def construct_fields(model, registry, only_fields, exclude_fields):
     _model_fields = get_model_fields(model)
@@ -35,9 +35,6 @@ def construct_fields(model, registry, only_fields, exclude_fields):
             continue
         fields[name] = converted
 
-    # print(model, model == Child)
-    # if model == Child:
-    #     print(fields)
     return fields, self_referenced
 
 


### PR DESCRIPTION
- Add `advanced_types.PointFieldType` for Mongoengine.fields.PointField` to resolve `type` and coordinate automatically.