### PR TITLE
Improve extensibility around DB querying in MongoengineConnectionField

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -117,7 +117,13 @@ class MongoengineConnectionField(ConnectionField):
                 # https://github.com/graphql-python/graphene/issues/124
                 args['pk'] = from_global_id(id)[-1]
 
+            if getattr(cls, "before_get_query_filter", None):
+                args, before_filter_setup = cls.before_get_query_filter(args)
             objs = objs.filter(**args)
+            if getattr(cls, "after_get_query_filter", None):
+                objs, args = cls.after_get_query_filter(objs,
+                                                        args,
+                                                        before_filter_setup)
 
             # https://github.com/graphql-python/graphene-mongo/issues/21
             if after is not None:

--- a/graphene_mongo/tests/test_fields.py
+++ b/graphene_mongo/tests/test_fields.py
@@ -38,4 +38,3 @@ def test_before_and_after_hooks(fixtures):
                                             **{'my_headline_arg': 'World'})
     assert list_length == 1
     assert queryset[0].headline == 'World'
-    print(list_length)

--- a/graphene_mongo/tests/test_fields.py
+++ b/graphene_mongo/tests/test_fields.py
@@ -1,5 +1,8 @@
 from ..fields import MongoengineConnectionField
 from .types import ArticleNode
+from .models import Article
+from .setup import fixtures
+from graphene import String
 
 
 def test_field_args():
@@ -14,3 +17,25 @@ def test_field_args():
     default_args = ['after', 'last', 'first', 'before']
     args = field_args + reference_args + default_args
     assert set(field.args) == set(args)
+
+
+class MyExtendedConnectionField(MongoengineConnectionField):
+    @classmethod
+    def before_get_query_filter(cls, args):
+        my_headline_arg = args.pop('my_headline_arg', None)
+        before_filter_setup = {'headline': my_headline_arg}
+        return args, before_filter_setup
+
+    @classmethod
+    def after_get_query_filter(cls, queryset, args, before_filter_setup):
+        queryset = queryset.filter(headline=before_filter_setup['headline'])
+        return queryset, args
+
+
+def test_before_and_after_hooks(fixtures):
+    field = MyExtendedConnectionField(ArticleNode)
+    queryset, list_length = field.get_query(Article, {},
+                                            **{'my_headline_arg': 'World'})
+    assert list_length == 1
+    assert queryset[0].headline == 'World'
+    print(list_length)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ exclude = setup.py,docs/*,examples/*
 max-line-length = 130
 per-file-ignores =
     graphene_mongo/tests/test_mutation.py: F401, F811
+    graphene_mongo/tests/test_fields.py: F401, F811
     graphene_mongo/tests/test_query.py: F401, F811
     graphene_mongo/tests/test_relay_query.py: F401, F811
 [coverage:run]


### PR DESCRIPTION
In MongoengineConnectionField, the `get_query` method gatekeeps a pretty critical aspect of the field (namely manipulating args that go into the queryset filter call, as well as manipulating the eventual queryset itself). 

Anyone wanting to do the above (which opens up numerous possibilities in extending the field, such as advanced filtering, ordering, etc. etc.)  has to re-implement the entire method in a subclass, which is far from ideal.

This pull requests implements a couple of simple before and after hooks around the `objs = objs.filter(**args)` call in the method. An trivial example of usage is in `tests/test_fields.py`.

Let me know if there are any comments or issues with the implementation, and I'll be happy to see what I can do.