### PR TITLE
Add list_length to connection returned by default_resolver in MongoengineConnectionField

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -161,6 +161,7 @@ class MongoengineConnectionField(ConnectionField):
             pageinfo_type=PageInfo,
         )
         connection.iterable = objs
+        connection.list_length = list_length
         return connection
 
     def chained_resolver(self, resolver, root, info, **args):

--- a/graphene_mongo/tests/test_fields.py
+++ b/graphene_mongo/tests/test_fields.py
@@ -1,5 +1,6 @@
 from ..fields import MongoengineConnectionField
 from .types import ArticleNode, PublisherNode, ErroneousModelNode
+from .setup import fixtures
 
 
 def test_field_args():
@@ -35,3 +36,11 @@ def test_default_resolver_with_colliding_objects_field():
 
     connection = field.default_resolver(None, {})
     assert 0 == len(connection.iterable)
+
+
+def test_default_resolver_connection_list_length(fixtures):
+    field = MongoengineConnectionField(ArticleNode)
+
+    connection = field.default_resolver(None, {})
+    assert hasattr(connection, 'list_length')
+    assert connection.list_length == 2

--- a/graphene_mongo/tests/test_fields.py
+++ b/graphene_mongo/tests/test_fields.py
@@ -41,6 +41,6 @@ def test_default_resolver_with_colliding_objects_field():
 def test_default_resolver_connection_list_length(fixtures):
     field = MongoengineConnectionField(ArticleNode)
 
-    connection = field.default_resolver(None, {})
+    connection = field.default_resolver(None, {}, **{'first': 1})
     assert hasattr(connection, 'list_length')
     assert connection.list_length == 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ per-file-ignores =
     graphene_mongo/tests/test_mutation.py: F401, F811
     graphene_mongo/tests/test_query.py: F401, F811
     graphene_mongo/tests/test_relay_query.py: F401, F811
+    graphene_mongo/tests/test_fields.py: F401, F811
 [coverage:run]
 omit = */tests/*
 


### PR DESCRIPTION
The recent changes to MongoengineConnectionField are great; however, one change was that the length of the queryset results is no longer applied to the connection object returned by the default_resolver.

This means that if someone were to implement a special Connection class such as below that provides a totalCount field (pretty common use case), the count() method has to be called a second time.

```
class CountableConnectionBase(Connection):
    class Meta:
        abstract = True

    total_count = graphene.Int()

    def resolve_total_count(self, info, **kwargs):
        # To get the totalCount with the current impl. we have to query again
        return self.iterable.count()

        # Would be better if we could return this, right?
        # return self.list_length
```

I'm not sure how much worse having to call count() a second time actually is (it might depend on various things), but I'd like opinions on whether it makes sense to just append the list_length to the connection so that we can avoid calling twice (as in this PR). Is there a reason not to append it?

Otherwise, would welcome suggestions on another way to avoid the second call.