### PR TITLE
Fix 'in' filter argument generation

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -110,8 +110,18 @@ class MongoengineConnectionField(ConnectionField):
         if self._type._meta.filter_fields:
             for field, filter_collection in self._type._meta.filter_fields.items():
                 for each in filter_collection:
-                    filter_args[field + "__" + each] = graphene.Argument(
-                        type=getattr(graphene, str(self._type._meta.fields[field].type).replace("!", "")))
+                    filter_type = getattr(
+                        graphene, str(self._type._meta.fields[field].type).replace("!", ""))
+
+                    # handle special cases
+                    advanced_filter_types = {
+                        'in': graphene.List(filter_type),
+                        'nin': graphene.List(filter_type),
+                        'all': graphene.List(filter_type),
+                    }
+
+                    filter_type = advanced_filter_types.get(each, filter_type)
+                    filter_args[field + "__" + each] = graphene.Argument(type=filter_type)
 
         return filter_args
 

--- a/graphene_mongo/tests/nodes.py
+++ b/graphene_mongo/tests/nodes.py
@@ -43,7 +43,7 @@ class PlayerNode(MongoengineObjectType):
         model = models.Player
         interfaces = (Node, )
         filter_fields = {
-            'first_name': ['istartswith']}
+            'first_name': ['istartswith', 'in']}
 
 
 class ReporterNode(MongoengineObjectType):

--- a/graphene_mongo/tests/test_relay_query.py
+++ b/graphene_mongo/tests/test_relay_query.py
@@ -1077,3 +1077,42 @@ def test_should_filter_mongoengine_queryset(fixtures):
 
     assert not result.errors
     assert json.dumps(result.data, sort_keys=True) == json.dumps(expected, sort_keys=True)
+
+
+def test_should_filter_mongoengine_queryset_with_list(fixtures):
+
+    class Query(graphene.ObjectType):
+        players = MongoengineConnectionField(nodes.PlayerNode)
+
+    query = '''
+        query players {
+            players(firstName_In: ["Michael", "Magic"]) {
+                edges {
+                    node {
+                        firstName
+                    }
+                }
+            }
+        }
+    '''
+    expected = {
+        'players': {
+            'edges': [
+                {
+                    'node': {
+                        'firstName': 'Michael',
+                    }
+                },
+                {
+                    'node': {
+                        'firstName': 'Magic'
+                    }
+                }
+            ]
+        }
+    }
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+
+    assert not result.errors
+    assert json.dumps(result.data, sort_keys=True) == json.dumps(expected, sort_keys=True)


### PR DESCRIPTION
This corrects the behaviour of `MongoengineConnectionField.field_args` regarding the `in` filter option -- in that case, the argument type should be a list of the field type.

I know of `graphene-mongoengine-extras` but I think `<field_name>__in` is pretty standard and should work out of the box.

I dislike the check for 'in' specifically, but I don't know of a better way to do it.