### PR TITLE
Support for objects.order_by

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -51,6 +51,10 @@ class MongoengineConnectionField(ConnectionField):
         return self.node_type._meta.model
 
     @property
+    def order_by(self):
+        return self.node_type._meta.order_by
+
+    @property
     def registry(self):
         return getattr(self.node_type._meta, "registry", get_global_registry())
 
@@ -182,7 +186,7 @@ class MongoengineConnectionField(ConnectionField):
                 return queryset_or_filters
             else:
                 args.update(queryset_or_filters)
-        return model.objects(**args)
+        return model.objects(**args).order_by(self.order_by)
 
     def default_resolver(self, _root, info, **args):
         args = args or {}

--- a/graphene_mongo/tests/test_types.py
+++ b/graphene_mongo/tests/test_types.py
@@ -130,6 +130,15 @@ def test_mongoengine_objecttype_exclude_fields():
 
 
 @with_local_registry
+def test_mongoengine_objecttype_order_by():
+    class A(MongoengineObjectType):
+        class Meta:
+            model = Article
+            order_by = "some_order_by_statement"
+    assert "some_order_by_statement" not in list(A._meta.fields.keys())
+
+
+@with_local_registry
 def test_passing_meta_when_subclassing_mongoengine_objecttype():
     class TypeSubclassWithBadOptions(MongoengineObjectType):
         class Meta:

--- a/graphene_mongo/types.py
+++ b/graphene_mongo/types.py
@@ -71,6 +71,7 @@ class MongoengineObjectTypeOptions(ObjectTypeOptions):
     registry = None  # type: Registry
     connection = None
     filter_fields = ()
+    order_by = None
 
 
 class MongoengineObjectType(ObjectType):
@@ -89,6 +90,7 @@ class MongoengineObjectType(ObjectType):
         connection_field_class=None,
         interfaces=(),
         _meta=None,
+        order_by=None,
         **options
     ):
 
@@ -155,6 +157,7 @@ class MongoengineObjectType(ObjectType):
         # Save them for later
         _meta.only_fields = only_fields
         _meta.exclude_fields = exclude_fields
+        _meta.order_by = order_by
 
         super(MongoengineObjectType, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options


### PR DESCRIPTION
Use it like this:
class XXX(MongoengineObjectType):
    class Meta:
        model:SomeModel
        interfaces:(Node,)
        order_by: 'some order_by clause used by
                   SomeeModel.object().order_by'

That's all, try it out.

Signed-off-by: Zhang Yuzheng <me@zhanyuzheng.com>