### PR TITLE
Fixed issue 125, added list_slice_length to default resolver

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -213,6 +213,7 @@ class MongoengineConnectionField(ConnectionField):
             list_slice=iterables,
             args=connection_args,
             list_length=list_length,
+            list_slice_length=list_length,
             connection_type=self.type,
             edge_type=self.type.Edge,
             pageinfo_type=graphene.PageInfo,


### PR DESCRIPTION
Hello :)

By using the length generated by list_length = iterables.count() in default_resolver and giving it as the argument list_slice_length to connection_from_list_slice, the following code is avoided in connection_from_list_slice (graphql_relay):

if list_slice_length is None:
        list_slice_length = len(list_slice)

Looks like this is a very expensive operation for calculating the queryset length.

This reduced the time required to grab the first n objects of a collection of 12000 from +2s to 0.02s.

Passes all tests.