### PR TITLE
Fixing fragment spread oversight

### DIFF
--- a/graphene_mongo/fields.py
+++ b/graphene_mongo/fields.py
@@ -512,9 +512,11 @@ class MongoengineConnectionField(ConnectionField):
                     args.update(resolved._query)
                     args_copy = args.copy()
                     for arg_name, arg in args.copy().items():
-                        if "." in arg_name or arg_name not in self.model._fields_ordered + (
-                                'first', 'last', 'before', 'after') + tuple(
-                            self.filter_args.keys()):
+                        if "." in arg_name or arg_name not in (
+                            self.model._fields_ordered +
+                            ('first', 'last', 'before', 'after') +
+                            tuple(self.filter_args.keys())
+                        ):
                             args_copy.pop(arg_name)
                             if arg_name == '_id' and isinstance(arg, dict):
                                 operation = list(arg.keys())[0]
@@ -549,7 +551,7 @@ class MongoengineConnectionField(ConnectionField):
                 if value:
                     try:
                         setattr(root, key, from_global_id(value)[1])
-                    except Exception as error:
+                    except Exception:
                         pass
         iterable = resolver(root, info, **args)
 

--- a/graphene_mongo/tests/test_utils.py
+++ b/graphene_mongo/tests/test_utils.py
@@ -1,5 +1,7 @@
-from ..utils import get_model_fields, is_valid_mongoengine_model
+from ..utils import get_model_fields, is_valid_mongoengine_model, get_query_fields
 from .models import Article, Reporter, Child
+from . import types
+import graphene
 
 
 def test_get_model_fields_no_duplication():
@@ -36,3 +38,66 @@ def test_get_base_model_fields():
 
 def test_is_valid_mongoengine_mode():
     assert is_valid_mongoengine_model(Reporter)
+
+
+def test_get_query_fields():
+    # Grab ResolveInfo objects from resolvers and set as nonlocal variables outside
+    # Can't assert within resolvers, as the resolvers may not be run if there is an exception
+    class Query(graphene.ObjectType):
+        child = graphene.Field(types.ChildType)
+        children = graphene.List(types.ChildUnionType)
+
+        def resolve_child(self, info, *args, **kwargs):
+            test_get_query_fields.child_info = info
+
+        def resolve_children(self, info, *args, **kwargs):
+            test_get_query_fields.children_info = info
+
+    query = """
+        query Query {
+            child {
+                bar
+                ...testFragment
+            }
+            children {
+                ... on ChildType{
+                    baz
+                    ...testFragment
+                }
+                ... on AnotherChildType {
+                    qux
+                }
+            }
+        }
+
+        fragment testFragment on ChildType {
+            loc {
+                type
+                coordinates
+            }
+        }
+    """
+
+    schema = graphene.Schema(query=Query)
+    schema.execute(query)
+
+    assert get_query_fields(test_get_query_fields.child_info) == {
+        'bar': {},
+        'loc': {
+            'type': {},
+            'coordinates': {}
+        }
+    }
+
+    assert get_query_fields(test_get_query_fields.children_info) == {
+        'ChildType': {
+            'baz': {},
+            'loc': {
+                'type': {},
+                'coordinates': {}
+            }
+        },
+        'AnotherChildType': {
+            'qux': {}
+        }
+    }

--- a/graphene_mongo/utils.py
+++ b/graphene_mongo/utils.py
@@ -139,7 +139,7 @@ def collect_query_fields(node, fragments):
                     leaf.name.value: collect_query_fields(leaf, fragments)
                 })
             elif leaf.kind == 'fragment_spread':
-                field.update(collect_query_fields(fragments[leaf['name']['value']],
+                field.update(collect_query_fields(fragments[leaf.name.value],
                                                   fragments))
             elif leaf.kind == 'inline_fragment':
                 field.update({


### PR DESCRIPTION
Trying to use fragments ended up in a FragmentSpreadNode is not subscriptable error. This is because there was an oversight when updating to Graphene 3 (I think). I've updated it and added a test that should check `get_query_fields`.