### PR TITLE
drop singledispatch package dependency

### DIFF
--- a/graphene_mongo/__init__.py
+++ b/graphene_mongo/__init__.py
@@ -3,7 +3,7 @@ from .fields_async import AsyncMongoengineConnectionField
 from .types import MongoengineInputType, MongoengineInterfaceType, MongoengineObjectType
 from .types_async import AsyncMongoengineObjectType
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "__version__",

--- a/graphene_mongo/converter.py
+++ b/graphene_mongo/converter.py
@@ -9,15 +9,13 @@ from graphene.utils.str_converters import to_snake_case, to_camel_case
 from mongoengine.base import get_document, LazyReference
 from . import advanced_types
 from .utils import (
-    import_single_dispatch,
     get_field_description,
     get_query_fields,
     ExecutorEnum,
     sync_to_async,
 )
 from concurrent.futures import ThreadPoolExecutor, as_completed
-
-singledispatch = import_single_dispatch()
+from functools import singledispatch
 
 
 class MongoEngineConversionError(Exception):

--- a/graphene_mongo/utils.py
+++ b/graphene_mongo/utils.py
@@ -55,29 +55,6 @@ def is_valid_mongoengine_model(model):
     )
 
 
-def import_single_dispatch():
-    try:
-        from functools import singledispatch
-    except ImportError:
-        singledispatch = None
-
-    if not singledispatch:
-        try:
-            from singledispatch import singledispatch
-        except ImportError:
-            pass
-
-    if not singledispatch:
-        raise Exception(
-            "It seems your python version does not include "
-            "functools.singledispatch. Please install the 'singledispatch' "
-            "package. More information here: "
-            "https://pypi.python.org/pypi/singledispatch"
-        )
-
-    return singledispatch
-
-
 # noqa
 def get_type_for_document(schema, document):
     types = schema.types.values()

--- a/poetry.lock
+++ b/poetry.lock
@@ -499,21 +499,6 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "singledispatch"
-version = "4.1.0"
-description = "Backport functools.singledispatch to older Pythons."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "singledispatch-4.1.0-py2.py3-none-any.whl", hash = "sha256:6061bd291204beaeac90cdbc342b68d213b7a6efb44ae6c5e6422a78be351c8a"},
-    {file = "singledispatch-4.1.0.tar.gz", hash = "sha256:f3430b886d5b4213d07d715096a75da5e4a8105284c497b9aee6d6d48bfe90cb"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ python = ">=3.8,<4"
 graphene = ">=3.1.1"
 promise = ">=2.3"
 mongoengine = ">=0.27"
-singledispatch = ">=4.1.0"
 asgiref = "^3.7.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "graphene-mongo"
 packages = [{ include = "graphene_mongo" }]
-version = "0.4.2"
+version = "0.4.3"
 description = "Graphene Mongoengine integration"
 authors = [
     "Abaw Chen <abaw.chen@gmail.com>",


### PR DESCRIPTION
Drop singledispatch package dependency altogether.

**Rationale**
What the singledispatch import function does is try to fetch it from the builtin functools module first and in case of a failure get it from the singledispatch pakakge. Python added singledispatch in functools in v3.4 and the lowest supported python version for graphene-mongo is v3.8. This means that the singledisptach import is always going to happen from functools and hence the dependency on singledispatch package is simply an overhead, not to mention removing it allows cleaning up a part of code that never gets executed,